### PR TITLE
fix(styles): add missing Sass files and update the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 _site/
 .sass-cache/
 .DS_Store
-vendor
+./vendor
 .bundle

--- a/_stylesheets/vendor/_rouge.scss
+++ b/_stylesheets/vendor/_rouge.scss
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------------
+// This file contains all styles for the Rouge highlighter
+// -----------------------------------------------------------------------------
+
+.highlight {
+  .hll { background-color: #ffffcc }
+  .c { color: #008000 } /* Comment */
+  .err { border: 1px solid #FF0000 } /* Error */
+  .k { color: #0000ff } /* Keyword */
+  .cm { color: #008000 } /* Comment.Multiline */
+  .cp { color: #0000ff } /* Comment.Preproc */
+  .c1 { color: #008000 } /* Comment.Single */
+  .cs { color: #008000 } /* Comment.Special */
+  .ge { font-style: italic } /* Generic.Emph */
+  .gh { font-weight: bold } /* Generic.Heading */
+  .gp { font-weight: bold } /* Generic.Prompt */
+  .gs { font-weight: bold } /* Generic.Strong */
+  .gu { font-weight: bold } /* Generic.Subheading */
+  .kc { color: #0000ff } /* Keyword.Constant */
+  .kd { color: #0000ff } /* Keyword.Declaration */
+  .kn { color: #0000ff } /* Keyword.Namespace */
+  .kp { color: #0000ff } /* Keyword.Pseudo */
+  .kr { color: #0000ff } /* Keyword.Reserved */
+  .kt { color: #2b91af } /* Keyword.Type */
+  .s { color: #a31515 } /* Literal.String */
+  .nc { color: #2b91af } /* Name.Class */
+  .ow { color: #0000ff } /* Operator.Word */
+  .sb { color: #a31515 } /* Literal.String.Backtick */
+  .sc { color: #a31515 } /* Literal.String.Char */
+  .sd { color: #a31515 } /* Literal.String.Doc */
+  .s2 { color: #a31515 } /* Literal.String.Double */
+  .se { color: #a31515 } /* Literal.String.Escape */
+  .sh { color: #a31515 } /* Literal.String.Heredoc */
+  .si { color: #a31515 } /* Literal.String.Interpol */
+  .sx { color: #a31515 } /* Literal.String.Other */
+  .sr { color: #a31515 } /* Literal.String.Regex */
+  .s1 { color: #a31515 } /* Literal.String.Single */
+  .ss { color: #a31515 } /* Literal.String.Symbol */
+}

--- a/_stylesheets/vendor/_workable.scss
+++ b/_stylesheets/vendor/_workable.scss
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------------
+// This file contains all styles for the Workable widget
+// -----------------------------------------------------------------------------
+
+#whr_embed_hook {
+  h3 {
+    font-size: 2em;
+  }
+
+  ul {
+    padding-left: 0;
+
+    li {
+      list-style: none;
+    }
+  }
+
+  .whr-date {
+    display: none;
+  }
+}


### PR DESCRIPTION
Fixes a broken build, introduced by #13, by adding missing Sass stylesheets that were missed due to the _.gitignore_ ignoring all directories named `vendor`. 