### PR TITLE
 feat(jobs): reconnect the jobs page and replace all links to careers.godaddy.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,9 +2,9 @@
 name: GoDaddy Open Source Center
 email: opensource@godaddy.com
 description: > # this means to ignore newlines until the next key
-  Official GoDaddy open source engineering page, showcasing
-  open source libraries and projects created by GoDaddy
-  engineering teams.
+  Information from our engineering team about the technology and tools we
+  use to create software which empowers small businesses around the world
+  to build and market their digital identities.
 url: "https://godaddy.github.io"
 
 twitter_username: GodaddyOSS

--- a/_includes/component/cta.html
+++ b/_includes/component/cta.html
@@ -4,7 +4,7 @@
       <p>When you join GoDaddy you’ll realize we work differently – ordinary isn’t part of our DNA. We believe when imaginations run wild you can achieve amazing accomplishments.</p>
     </div>
     <div class="card-action">
-      <a style="border-radius:0; width: auto; padding: 0 10px;" class="btn btn-floating" href="/jobs">
+      <a style="border-radius:0; width: auto; padding: 0 10px;" class="btn btn-floating" href="/jobs" title="Work at GoDaddy">
         Join us!
       </a>
     </div>

--- a/_includes/component/cta.html
+++ b/_includes/component/cta.html
@@ -4,8 +4,8 @@
       <p>When you join GoDaddy you’ll realize we work differently – ordinary isn’t part of our DNA. We believe when imaginations run wild you can achieve amazing accomplishments.</p>
     </div>
     <div class="card-action">
-      <a style="border-radius:0; width: auto; padding: 0 10px;" class="btn btn-floating" href="https://careers.godaddy.com">
-        Careers
+      <a style="border-radius:0; width: auto; padding: 0 10px;" class="btn btn-floating" href="/jobs">
+        Join us!
       </a>
     </div>
   </div>

--- a/_includes/component/navigation.html
+++ b/_includes/component/navigation.html
@@ -24,8 +24,8 @@
           </a>
         </li>
         <li>
-          <a href="https://careers.godaddy.com" class="waves-effect waves-light btn inverse">
-            Careers
+          <a href="/jobs" class="waves-effect waves-light btn inverse">
+            Join us!
           </a>
         </li>
       </ul>
@@ -49,8 +49,8 @@
           </a>
         </li>
         <li>
-          <a href="https://careers.godaddy.com" class="waves-effect waves-light btn inverse">
-            Careers
+          <a href="/jobs" class="waves-effect waves-light btn inverse">
+            Join us!
           </a>
         </li>
       </ul>

--- a/_includes/component/navigation.html
+++ b/_includes/component/navigation.html
@@ -4,52 +4,52 @@
       <a href="{{ site.url }}" title="GoDaddy Open Source" class="left brand-logo">
         GoDaddy Open Source
       </a>
-      <a href="#" data-activates="mobile-demo" class="right button-collapse">
+      <a href="#" data-activates="mobile-demo" class="right button-collapse" title="Home">
         <i class="material-icons">menu</i>
       </a>
       <ul class="right hide-on-med-and-down" id="nav-mobile">
         <li>
-          <a href="/featured-projects">
+          <a href="/featured-projects" title="Featured projects">
             Featured projects
           </a>
         </li>
         <li>
-          <a href="/blog-posts">
+          <a href="/blog-posts" title="Blog posts">
             Blog posts
           </a>
         </li>
         <li>
-          <a href="/code-of-conduct">
+          <a href="/code-of-conduct" title="Code of Conduct">
             Code of Conduct
           </a>
         </li>
         <li>
-          <a href="/jobs" class="waves-effect waves-light btn inverse">
+          <a href="/jobs" class="waves-effect waves-light btn inverse" title="Join us!">
             Join us!
           </a>
         </li>
       </ul>
       <ul class="side-nav" id="mobile-demo">
         <li>
-          <a href="/">Home</a>
+          <a href="/" title="Home">Home</a>
         </li>
         <li>
-          <a href="/featured-projects">
+          <a href="/featured-projects" title="Featured projects">
             Featured projects
           </a>
         </li>
         <li>
-          <a href="/blog-posts">
+          <a href="/blog-posts" title="Blog posts">
             Blog posts
           </a>
         </li>
         <li>
-          <a href="/code-of-conduct">
+          <a href="/code-of-conduct" title="Code of Conduct">
             Code of Conduct
           </a>
         </li>
         <li>
-          <a href="/jobs" class="waves-effect waves-light btn inverse">
+          <a href="/jobs" class="waves-effect waves-light btn inverse" title="Work at GoDaddy">
             Join us!
           </a>
         </li>

--- a/_includes/section/footer.html
+++ b/_includes/section/footer.html
@@ -6,7 +6,7 @@
           <p class="grey-text text-lighten-4">
             When you join GoDaddy you’ll realize we work differently – ordinary isn’t part of our DNA.
             We believe when imaginations run wild you can achieve amazing accomplishments.
-            <a href="https://careers.godaddy.com" title="Working at GoDaddy">Learn more</a>
+            <a href="/jobs" title="Work at GoDaddy">Join us!</a>
           </p>
         </div>
         <div class="col m4 offset-l2 s12">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -50,7 +50,7 @@
             <ul>
               <li><a class="grey-text text-lighten-3" href="https://github.com/godaddy">GitHub</a></li>
               <li><a class="grey-text text-lighten-3" href="https://twitter.com/GodaddyOSS">Twitter</a></li>
-              <li><a class="grey-text text-lighten-3" href="https://careers.godaddy.com">Careers</a></li>
+              <li><a class="grey-text text-lighten-3" href="/jobs">Join us!</a></li>
             </ul>
           </div>
         </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -50,7 +50,7 @@
             <ul>
               <li><a class="grey-text text-lighten-3" href="https://github.com/godaddy">GitHub</a></li>
               <li><a class="grey-text text-lighten-3" href="https://twitter.com/GodaddyOSS">Twitter</a></li>
-              <li><a class="grey-text text-lighten-3" href="/jobs">Join us!</a></li>
+              <li><a class="grey-text text-lighten-3" href="/jobs" title="Work at GoDaddy">Join us!</a></li>
             </ul>
           </div>
         </div>

--- a/jobs.html
+++ b/jobs.html
@@ -4,13 +4,11 @@ slug: open-positions
 title: Open positions
 ---
 
-<h1>Open positions</h1>
-
 <div class="page-jobs">
-  <h2>Chase the big dreams. Blow past tiny doubts.</h2>
-  <div>
+  <h4>Chase the big dreams. Blow past tiny doubts.</h4>
+  <p class="flow-text">
     When you join GoDaddy you’ll realize we work differently–ordinary isn’t part of our DNA. We believe when imaginations run wild you can achieve amazing accomplishments. Make it happen.
-  </div>
+  </p>
   <div id="whr_embed_hook"></div>
 </div>
 


### PR DESCRIPTION
This PR reconnects the Jobs page, which was disconnected with #18. It also reverts the changes to the link, updates the site description to match the home page copy, and adds `title` attributes to the primary navigation links.

### Screenshot

![screen shot 2018-05-04 at 10 07 06 am](https://user-images.githubusercontent.com/1934719/39641664-e7dd90f6-4f83-11e8-8fc7-d0d23f801fce.png)
