### PR TITLE
Display multiple project cards per row on large screens

### DIFF
--- a/blog-posts.html
+++ b/blog-posts.html
@@ -7,7 +7,7 @@ title: Blog posts
 <div class="blog-posts">
   <div class="row">
   {% for post in site.posts %}
-    <div class="col s12 m6">
+    <div class="col s12 m6 l4">
       <div class="card medium">
         <div class="card-image waves-effect waves-block waves-light">
           <img class="activator" src="{{ post.cover }}">
@@ -26,4 +26,3 @@ title: Blog posts
   {% endfor %}
   </div>
 </div>
-

--- a/featured-projects.html
+++ b/featured-projects.html
@@ -6,7 +6,7 @@ title: Featured projects
 
 <div class="row">
   {% for project in site.data.projects %}
-  <div class="col s12">
+  <div class="col col s12 m6 l4">
     {% include component/project-card.html project=project %}
   </div>
   {% endfor %}


### PR DESCRIPTION
This is an attempt to address https://github.com/godaddy/godaddy.github.io/issues/17 using Materialize's [built-in grid utilities](https://materializecss.com/grid.html). Additionally, this provides some very basic responsiveness to both the featured projects **and** the blog posts, so we can have a consistent experience across the site. Here are some screenshots to expedite the review process:

# Desktop

<img width="1269" alt="screen shot 2018-05-04 at 10 45 24 am" src="https://user-images.githubusercontent.com/6868877/39643043-4ff85af0-4f88-11e8-8b7e-00df065aec6f.png">

# Mobile

<img height="400" alt="screen shot 2018-05-04 at 10 45 24 am" src="https://user-images.githubusercontent.com/6868877/39643133-9068e668-4f88-11e8-95d6-6d087fba5081.png">

# Tablet 

<img height="800" alt="screen shot 2018-05-04 at 10 45 24 am" src="https://user-images.githubusercontent.com/6868877/39643182-bf5394c8-4f88-11e8-9d5b-fd0d0b083846.png">
