### PR TITLE
revert(styles): responsive featured projects and blog posts

### DIFF
--- a/blog-posts.html
+++ b/blog-posts.html
@@ -7,7 +7,7 @@ title: Blog posts
 <div class="blog-posts">
   <div class="row">
   {% for post in site.posts %}
-    <div class="col s12 m6 l4">
+    <div class="col s12 m6">
       <div class="card medium">
         <div class="card-image waves-effect waves-block waves-light">
           <img class="activator" src="{{ post.cover }}">
@@ -26,3 +26,4 @@ title: Blog posts
   {% endfor %}
   </div>
 </div>
+

--- a/featured-projects.html
+++ b/featured-projects.html
@@ -6,7 +6,7 @@ title: Featured projects
 
 <div class="row">
   {% for project in site.data.projects %}
-  <div class="col col s12 m6 l4">
+  <div class="col s12">
     {% include component/project-card.html project=project %}
   </div>
   {% endfor %}


### PR DESCRIPTION
This PR reverts commit aadfab1564fd95857111b1d6c60c29a2cad6078b until we have a solution for responsive card content that also results in uniform card heights. CC (@SivanMehta)

#### Screenshots

_Current Projects_

![screen shot 2018-05-07 at 9 34 35 am](https://user-images.githubusercontent.com/1934719/39713110-5b19aa98-51da-11e8-837b-6c62333b19bb.png)

_After Revert_

![screen shot 2018-05-07 at 9 34 10 am](https://user-images.githubusercontent.com/1934719/39713114-5fc4bd12-51da-11e8-8013-cca68ac3910d.png)

_Current Blog Index_

![screen shot 2018-05-07 at 9 34 30 am](https://user-images.githubusercontent.com/1934719/39713121-6cdb0452-51da-11e8-843f-419d2c29a4b6.png)

_After Revert_

![screen shot 2018-05-07 at 9 34 38 am](https://user-images.githubusercontent.com/1934719/39713125-71734470-51da-11e8-8c27-58974a925295.png)
