### PR TITLE
feat(projects): render project cards with a uniform height

### DIFF
--- a/_includes/component/project-card.html
+++ b/_includes/component/project-card.html
@@ -1,17 +1,19 @@
-<div class="card card--project">
+<div class="card small hoverable card--project">
   <div class="card-stacked">
     <div class="card-content">
       <span class="card-title">
         {{ project.name }}
       </span>
 
-      <p>{{ project.description }}</p>
-      <p>
-        <em>Lead maintainer:
-          <a href="{{ project.maintainer.link }}">
-            {{ project.maintainer.name }}
-          </a>
-        </em>
+      <p class="m-b-default">
+        {{ project.description }}
+      </p>
+
+      <p class="text-small">
+        Lead maintainer:
+        <a href="{{ project.maintainer.link }}">
+          {{ project.maintainer.name }}
+        </a>
       </p>
     </div>
 

--- a/_stylesheets/base/_typography.scss
+++ b/_stylesheets/base/_typography.scss
@@ -12,6 +12,10 @@ h3 {
   text-align: justify;
 }
 
+.text-small {
+  font-size: .875em;
+}
+
 .text-primary-base {
   color: $primary-base;
 }

--- a/blog-posts.html
+++ b/blog-posts.html
@@ -8,7 +8,7 @@ title: Blog posts
   <div class="row">
   {% for post in site.posts %}
     <div class="col s12 m6">
-      <div class="card medium">
+      <div class="card hoverable medium">
         <div class="card-image waves-effect waves-block waves-light">
           <img class="activator" src="{{ post.cover }}">
         </div>

--- a/featured-projects.html
+++ b/featured-projects.html
@@ -6,7 +6,7 @@ title: Featured projects
 
 <div class="row">
   {% for project in site.data.projects %}
-  <div class="col s12">
+  <div class="col col s12 m6">
     {% include component/project-card.html project=project %}
   </div>
   {% endfor %}


### PR DESCRIPTION
This PR resolves #17 by utilizing the [small Materialize card](https://materializecss.com/cards.html#sizes) size class for project cards for medium screen sizes and above. All cards have been updated to elevate on hover, like the official [Material Design card elevation behavior](https://material.io/design/components/cards.html#behavior).

_Note: these cards look really nice [rendered 3-up on large screens](https://user-images.githubusercontent.com/1934719/39910868-0a8d139a-54ae-11e8-86a8-734a94f7e42d.png), but some of the current card descriptions won't fit without style changes, text edits, or truncation. I'm deferring those decisions for future work._

#### Screenshots

_Desktop_

![projects-example](https://user-images.githubusercontent.com/1934719/39910782-a4ae1240-54ad-11e8-83c1-9690bed27ee7.gif)

_Blog Index_

![example-posts](https://user-images.githubusercontent.com/1934719/39910789-ae7d61e0-54ad-11e8-8a66-8477ee3d386a.gif)

_Nexus 6_

<img width="418" alt="example-samsung" src="https://user-images.githubusercontent.com/1934719/39910742-84ad5cc6-54ad-11e8-98ab-f3e181ee37ed.png">

_iPhone 6_

<img width="356" alt="example-iphone" src="https://user-images.githubusercontent.com/1934719/39910747-899a3e66-54ad-11e8-8b91-5b1d018df4ca.png">

_iPhone Air 2_

<img width="535" alt="screen shot 2018-05-10 at 11 16 59 pm" src="https://user-images.githubusercontent.com/1934719/39910753-901e0b1e-54ad-11e8-84a2-86a373a15581.png">

