### PR TITLE
refactor(cta): updates the blog post CTA card to Bootstrap 4

### DIFF
--- a/_includes/component/cta.html
+++ b/_includes/component/cta.html
@@ -1,10 +1,10 @@
-<div class="card horizontal">
-  <div class="card-stacked white-text">
-    <div class="card-content blue">
-      <p>When you join GoDaddy you’ll realize we work differently – ordinary isn’t part of our DNA. We believe when imaginations run wild you can achieve amazing accomplishments.</p>
-    </div>
-    <div class="card-action">
-      <a style="border-radius:0; width: auto; padding: 0 10px;" class="btn btn-floating" href="https://careers.godaddy.com/?source=APPLICANT_SOURCE-3-118&utm_source=godaddy-oss" title="Work at GoDaddy">
+<div class="card mb-3 shadow border-0">
+  <div class="card-body p-0">
+    <p class="card-text p-3 mb-0 bg-secondary-base text-light">
+      When you join GoDaddy you’ll realize we work differently – ordinary isn’t part of our DNA. We believe when imaginations run wild you can achieve amazing accomplishments.
+    </p>
+    <div class="card-footer text-muted">
+      <a class="btn btn-primary shadowed" href="https://careers.godaddy.com/?source=APPLICANT_SOURCE-3-118&utm_source=godaddy-oss" title="Work at GoDaddy">
         Join us!
       </a>
     </div>


### PR DESCRIPTION
This PR resolves #32 by refactoring the blog post CTA component to use Bootstrap 4.

### Screenshot

_Large Desktop_

<img width="721" alt="screen shot 2018-05-21 at 8 30 19 pm" src="https://user-images.githubusercontent.com/1934719/40340800-fa14b1ea-5d35-11e8-84eb-bc607cee480a.png">

_Small Devices_

<img width="394" alt="screen shot 2018-05-21 at 8 30 33 pm" src="https://user-images.githubusercontent.com/1934719/40340804-01b4082e-5d36-11e8-9af6-345ab3d64afc.png">
