### PR TITLE
fix(page/home): add a min-height to the action cards

### DIFF
--- a/_stylesheets/appstyles.scss
+++ b/_stylesheets/appstyles.scss
@@ -21,6 +21,7 @@
 
 /* Components */
 @import 'components/button';
+@import 'components/card';
 @import 'components/masthead';
 @import 'components/project-card';
 

--- a/_stylesheets/components/_card.scss
+++ b/_stylesheets/components/_card.scss
@@ -1,0 +1,3 @@
+.action-cards .card {
+  min-height: 294px;
+}

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: home
 hide: true
 ---
 
-<div class="row">
+<div class="action-cards row">
   <div class="col-sm-6">
     <div class="card shadow border-0 mb-3 text-center">
       <div class="card-body">


### PR DESCRIPTION
This resolves #37 with a short-term fix that works with the current content. When the content of these cards are next updated it may be necessary to either update their `min-height` or include a more long-term solution. 

#### Screenshot

<img width="1321" alt="screen shot 2018-05-22 at 9 19 33 pm" src="https://user-images.githubusercontent.com/1934719/40403458-e9f5d63c-5e06-11e8-954c-7326e49e2b7f.png">
