### PR TITLE
refactor(social-links): use a data file to define the footer social links

### DIFF
--- a/_data/social.json
+++ b/_data/social.json
@@ -1,0 +1,33 @@
+[{
+  "link": "https://github.com/godaddy",
+  "provider": {
+    "displayName": "GitHub",
+    "slug": "github"
+  },
+  "username": "godaddy",
+  "visible": true
+}, {
+  "link": "https://twitter.com/GodaddyOSS",
+  "provider": {
+    "displayName": "Twitter",
+    "slug": "twitter"
+  },
+  "username": "GodaddyOSS",
+  "visible": true
+}, {
+  "link": "https://dribbble.com/GoDaddy",
+  "provider": {
+    "displayName": "Dribbble",
+    "slug": "dribbble"
+  },
+  "username": "GoDaddy",
+  "visible": true
+},{
+  "link": "https://www.facebook.com/GoDaddy",
+  "provider": {
+    "displayName": "Facebook",
+    "slug": "facebook"
+  },
+  "username": "GoDaddy",
+  "visible": true
+}]

--- a/_includes/component/social-links.html
+++ b/_includes/component/social-links.html
@@ -1,0 +1,11 @@
+<ul class="list-unstyled mb-0">
+  {% for item in site.data.social %}
+  {% if item.visible == true %}
+  <li>
+    <a class="text-light" href="{{ item.link }}" title="{{ item.username }} on {{ item.provider.displayName }}">
+      {{ item.provider.displayName }}
+    </a>
+  </li>
+  {% endif %}
+  {% endfor %}
+</ul>

--- a/_includes/section/footer.html
+++ b/_includes/section/footer.html
@@ -16,23 +16,7 @@
           <h5 class="text-white text-font-headline">
             On the web
           </h5>
-          <ul class="list-unstyled mb-0">
-            <li>
-              <a class="text-light" target="_blank" href="https://github.com/godaddy">
-                GitHub
-              </a>
-            </li>
-            <li>
-              <a class="text-light" target="_blank" href="https://twitter.com/GodaddyOSS">
-                Twitter
-              </a>
-            </li>
-            <li>
-              <a class="text-light" target="_blank" href="https://www.facebook.com/GoDaddy">
-                Facebook
-              </a>
-            </li>
-          </ul>
+          {% include component/social-links.html %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR moves the social profiles from hard-coded HTML into a JSON data file. It also adds a link to [GoDaddy on Dribble](https://dribbble.com/GoDaddy).

#### Screenshot 

_Updated footer_

<img width="346" alt="screen shot 2018-05-22 at 10 44 12 pm" src="https://user-images.githubusercontent.com/1934719/40405504-b037be0a-5e11-11e8-8c03-2bc89eeedc54.png">
