### PR TITLE
feat(post): add an optional drop cap feature for blog post layouts

### DIFF
--- a/_posts/2018-02-22-announcing-terminus.md
+++ b/_posts/2018-02-22-announcing-terminus.md
@@ -11,9 +11,9 @@ authors:
     photo: https://avatars2.githubusercontent.com/u/2174968?s=460
 ---
 
-Your application is serving requests constantly for your users. You and your team want to ship features and fixes as soon as they are ready, so you do continuous delivery. **But what happens to your users who used your product at the time of the deployment? Chances are, the requests they have in progress are going to fail.** This post helps you fix that.
+<span class="text-drop-cap">Y</span>our application is serving requests constantly for your users. You and your team want to ship features and fixes as soon as they are ready, so you do continuous delivery. **But what happens to your users who used your product at the time of the deployment? Chances are, the requests they have in progress are going to fail.** This post helps you fix that.
 
-# Graceful shutdown for Node.js
+### Graceful shutdown for Node.js
 
 When you deploy a new version of your application, the old must be replaced. The process manager you are using *(no matter if it is Heroku, Kubernetes, supervisor or anything else)* will first send a `SIGTERM` signal to the application to let it know, that it will be killed. Once it gets this signal, it should **stop accepting new requests, finish all the ongoing requests, and clean up the resources it used**. Resources may include database connections or file locks.
 
@@ -30,7 +30,7 @@ process.on('SIGTERM', () => {
 })
 ```
 
-# Health checks for Node.js applications
+### Health checks for Node.js applications
 
 Health checks of your applications are called by the load balancer of your application to let it know if the application instance is healthy, and can server traffic. If you are using Kubernetes, Kubernetes has two distinct health checks:
 
@@ -41,7 +41,7 @@ On how to set up health checks for Kubernetes, check out the official [Configure
 
 {% include component/cta.html %}
 
-# Enter `terminus`
+### Enter `terminus`
 
 [terminus](https://github.com/godaddy/terminus) is an open-source project, which adds health checks and graceful shutdown to your applications - to save you from the boilerplate code you would add otherwise. You only have to provide the cleanup logic for graceful shutdowns, and the health check logic for health checks, all the rest is handled by [terminus](https://github.com/godaddy/terminus).
 

--- a/_posts/2018-04-02-introducing-eslint-plugin-i18n-json.md
+++ b/_posts/2018-04-02-introducing-eslint-plugin-i18n-json.md
@@ -10,7 +10,7 @@ authors:
     photo: https://avatars0.githubusercontent.com/u/1103708?s=460&v=4
 ---
 
-Many web apps harness internationalization through frameworks such as React-Intl. This is awesome for the web and helps web apps obtain a global reach. 🗺
+<span class="text-drop-cap">M</span>any web apps harness internationalization through frameworks such as React-Intl. This is awesome for the web and helps web apps obtain a global reach. 🗺
 
 However, as translators or application developers add and remove messages, or create additional translation files to support new locales, the chance of having a malformed translation file increases.
 

--- a/_posts/2018-05-02-kubernetes-introduction-for-developers.md
+++ b/_posts/2018-05-02-kubernetes-introduction-for-developers.md
@@ -10,7 +10,7 @@ authors:
     photo: https://avatars2.githubusercontent.com/u/2174968?s=460
 ---
 
-As Kubernetes is becoming the de facto container orchestration platform, more and more application developers have started using the `kubectl` CLI tool. The purpose of this article is to provide application developers with a set of tools and best practices to become more confident when interacting with the Kubernetes cluster.
+<span class="text-drop-cap">A</span>s Kubernetes is becoming the de facto container orchestration platform, more and more application developers have started using the `kubectl` CLI tool. The purpose of this article is to provide application developers with a set of tools and best practices to become more confident when interacting with the Kubernetes cluster.
 
 At GoDaddy, we have been using Kubernetes for quite some time now - this article is the first edition of what will become a living document of our best practices.
 

--- a/_posts/2018-05-15-jiractl.md
+++ b/_posts/2018-05-15-jiractl.md
@@ -22,7 +22,7 @@ authors:
     photo: /assets/images/shughes.png
 ---
 
-At GoDaddy we use [Jira](https://www.atlassian.com/software/jira) to track and manage our projects. Jira has an extensive feature set that can be customized to different teams’ needs, but its customizability can make it difficult for developers to perform simple tasks during a sprint. Visiting the Jira UI to check sprint progress or update an issue takes a developer out of their normal workflow on the command line. During a recent hackathon, we decided to address this problem by building an opensource Jira CLI for managing our sprints.
+<span class="text-drop-cap">A</span>t GoDaddy we use [Jira](https://www.atlassian.com/software/jira) to track and manage our projects. Jira has an extensive feature set that can be customized to different teams’ needs, but its customizability can make it difficult for developers to perform simple tasks during a sprint. Visiting the Jira UI to check sprint progress or update an issue takes a developer out of their normal workflow on the command line. During a recent hackathon, we decided to address this problem by building an opensource Jira CLI for managing our sprints.
 
 There are a number of other Jira CLIs already out there; Atlassian sells one, there are a handful of opensource node-based Jira CLIs -- for example, [jira-node-cli](https://github.com/lusarz/jira-node-cli), [jira-console](https://github.com/faressoft/jira-console), and [JiraTool](https://github.com/WillBrock/JiraTool) -- and [go-jira](https://github.com/Netflix-Skunkworks/go-jira), a highly-starred tool written in Go.
 

--- a/_stylesheets/base/_typography.scss
+++ b/_stylesheets/base/_typography.scss
@@ -31,3 +31,14 @@ h3 {
 .text-font-headline {
   font-family: $text-headline-stack;
 }
+
+.text-drop-cap {
+  color: $black-base;
+  float: left;
+  font-family: Georgia, Cambria, "Times New Roman", Times, serif;
+  font-size: 75px;
+  line-height: 60px;
+  padding-top: 4px;
+  padding-right: 8px;
+  padding-left: 3px;
+}


### PR DESCRIPTION
Pulled from #42 (see screenshots there), this PR adds an optional, decorative drop cap for blog posts with enough lead text to support it. It also fixes up the headlines in one article that was rendering a bunch of `<h1>` tags onto the page.