### PR TITLE
feat(post): add an optional, full-bleed featured image to the blog posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,10 +4,16 @@ widgets:
   - twitter
 ---
 {% include section/header.html %}
-{% capture headline %}<h1>{{ page.title }}</h1>{% endcapture %}
-{% include component/masthead.html headline=headline %}
 
-<div class="container text-line-height-2x py-3">
+{% if page.options contains 'full-bleed-cover' %}
+<div class="cover-image" style="background-image: url({{ page.cover }});"></div>
+{% endif %}
+
+<div class="container text-line-height-2x pt-3">
+  <h1 class="mb-3">
+    {{ page.title }}
+  </h1>
+
   <div class="authors text-center">
     {% for author in page.authors %}
     <a href="{{ author.url }}" class="mb-3 badge border badge-light shadow-sm">

--- a/_posts/2018-04-04-isomorphic-asset-system-for-react-and-react-native.md
+++ b/_posts/2018-04-04-isomorphic-asset-system-for-react-and-react-native.md
@@ -4,6 +4,8 @@ title:  "Isomorphic Asset System for React and React-Native"
 date:   2018-04-04 02:00:00 -0800
 cover:  /assets/images/headers/isomorphic-asset-system.png
 excerpt: Introducing Asset System a cross platform asset rendering system for React and React-Native using SVG's.
+options:
+  - full-bleed-cover
 authors:
   - name: Arnout Kazemier
     url: https://github.com/3rd-Eden

--- a/_posts/2018-05-15-jiractl.md
+++ b/_posts/2018-05-15-jiractl.md
@@ -4,6 +4,8 @@ title: "jiractl: A command-line tool for managing Jira"
 date: 2018-05-15 08:53:01 -0800
 cover: /assets/images/headers/jiractl-cover.jpg
 excerpt: This post introduces jiractl, a command-line tool for managing Jira. We provide some instructions on how to set up and use jiractl.
+options:
+  - full-bleed-cover
 authors:
   - name: Emma Lubin
     url: https://twitter.com/lubin_emma

--- a/_stylesheets/layout/_post.scss
+++ b/_stylesheets/layout/_post.scss
@@ -2,4 +2,17 @@
   .container {
     max-width: 40em;
   }
+
+  .cover-image {
+    background-origin: border-box;
+    background-position: center;
+    background-size: cover;
+
+    height: auto;
+    margin-top: 0;
+    min-height: 210px;
+    width: 100%;
+
+    flex: 1 0 auto;
+  }
 }


### PR DESCRIPTION
This PR was pulled from #42 (see screenshots there), and adds an optional, full-bleed cover image for blog posts with featured images that look nice full width.