### PR TITLE
fix(post): remove duplicate authors panel from layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,15 +14,6 @@ widgets:
     {{ page.title }}
   </h1>
 
-  <div class="authors text-center">
-    {% for author in page.authors %}
-    <a href="{{ author.url }}" class="mb-3 badge border badge-light shadow-sm">
-      <img class="rounded" src="{{ author.photo }}" alt="{{ author.name }}" width="32">
-      {{ author.name }}
-    </a>
-    {% endfor %}
-  </div>
-
   {{ content }}
 
   {% include component/social-share.html %}

--- a/_posts/2018-05-15-jiractl.md
+++ b/_posts/2018-05-15-jiractl.md
@@ -4,8 +4,6 @@ title: "jiractl: A command-line tool for managing Jira"
 date: 2018-05-15 08:53:01 -0800
 cover: /assets/images/headers/jiractl-cover.jpg
 excerpt: This post introduces jiractl, a command-line tool for managing Jira. We provide some instructions on how to set up and use jiractl.
-options:
-  - full-bleed-cover
 authors:
   - name: Emma Lubin
     url: https://twitter.com/lubin_emma


### PR DESCRIPTION
Missed when separating #42, this removes the authors from the top of the blog post. They are now at the bottom.

Also removes the full-bleed featured image from the jiractl article, because it looks bad on 4K+ monitors.