### PR TITLE
feat(projects): make featured projects searchable

### DIFF
--- a/_data/projects.json
+++ b/_data/projects.json
@@ -13,7 +13,8 @@
   "maintainer": {
     "name": "Silas Boyd-Wickizer",
     "link": "https://github.com/silasbw"
-  }
+  },
+  "id": "kubernetes-client"
 },
 {
   "name": "datastar",
@@ -30,7 +31,8 @@
   "maintainer": {
     "name": "Jarrett Cruger",
     "link": "https://github.com/jcrugzz"
-  }
+  },
+  "id": "datastar"
 },
 {
   "name": "procfilter",
@@ -43,7 +45,8 @@
   "maintainer": {
     "name": "Emerson R. Wiley",
     "link": "https://github.com/ewil"
-  }
+  },
+  "id": "procfilter"
 }, {
   "name": "terminus",
   "description": "Graceful shutdown and Kubernetes readiness / liveness checks for any Node.js HTTP applications",
@@ -59,7 +62,8 @@
   "maintainer": {
     "name": "Gergely Nemeth",
     "link": "https://github.com/gergelyke"
-  }
+  },
+  "id": "terminus"
 }, {
   "name": "Asset System",
   "description": "A cross platform asset rendering system for React and React-Native using SVGs",
@@ -71,5 +75,6 @@
   "maintainer": {
     "name": "Arnout Kazemier",
     "link": "https://github.com/3rd-Eden"
-  }
+  },
+  "id": "asset-system"
 }]

--- a/_includes/block/scripts.html
+++ b/_includes/block/scripts.html
@@ -37,3 +37,10 @@
   }(document, "script", "twitter-wjs"));
 </script>
 {% endif %}
+
+{% if page.slug contains 'featured-projects' %}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.2.1/fuse.min.js"></script>
+<script>
+{% include scripts/filter-projects.js %}
+</script>
+{% endif %}

--- a/_includes/component/project-card.html
+++ b/_includes/component/project-card.html
@@ -1,4 +1,4 @@
-<div class="card mb-3 shadow border-0">
+<div class="card mb-3 shadow border-0" data-id={{ project.id }}>
   <div class="card-body">
     <h5 class="card-title text-font-headline">{{ project.name }}</h5>
     <p class="card-text">{{ project.description }}</p>

--- a/_includes/component/project-search.html
+++ b/_includes/component/project-search.html
@@ -1,0 +1,8 @@
+<div class="project-search">
+  <div class="input-group mb-3">
+    <div class="input-group-prepend">
+      <span class="input-group-text" id="label-search-projects">Search</span>
+    </div>
+    <input type="text" class="form-control control-project-search" placeholder='"Node.js", "API", "Silas"' aria-label="Search projects" aria-describedby="label-search-projects">
+  </div>
+</div>

--- a/_includes/scripts/filter-projects.js
+++ b/_includes/scripts/filter-projects.js
@@ -3,7 +3,7 @@ $(function () {
   if (!Fuse || typeof Fuse !== 'function') return;
 
   var $searchInput = $('.control-project-search');
-  var $cards = $('.card');
+  var $cards = $('.project-cards .card');
 
   var fuseOptions = {
     findAllMatches: true,

--- a/_includes/scripts/filter-projects.js
+++ b/_includes/scripts/filter-projects.js
@@ -1,0 +1,38 @@
+$(function () {
+  if (!projects || !$.isArray(projects) || !projects.length > 0) return;
+  if (!Fuse || typeof Fuse !== 'function') return;
+
+  var $searchInput = $('.control-project-search');
+  var $cards = $('.card');
+
+  var fuseOptions = {
+    findAllMatches: true,
+    threshold: 0.3,
+    minMatchCharLength: 2,
+    distance: 255,
+    keys: ['description', 'name', 'maintainer.name']
+  };
+  var fuse = new Fuse(projects, fuseOptions);
+
+  function filterQueryMatch(event) {
+    var searchFor = event.currentTarget.value;
+    var hasQuery = searchFor.length > 0;
+    var results = fuse.search(searchFor);
+    var matches = results.map(function (project) {
+      return project.id;
+    });
+
+    $cards.each(function (i, card) {
+      var $card = $(card);
+      var isMatch = matches.indexOf($card.data('id')) >= 0;
+
+      if (!hasQuery || isMatch) {
+        $(card).removeClass('d-none');
+      } else {
+        $(card).addClass('d-none');
+      }
+    });
+  }
+
+  $searchInput.on('input', filterQueryMatch);
+});

--- a/featured-projects.html
+++ b/featured-projects.html
@@ -5,6 +5,15 @@ layout: default
 order: 1
 ---
 
+<div class="project-search">
+  <div class="input-group mb-3">
+    <div class="input-group-prepend">
+      <span class="input-group-text" id="label-search-projects">Search</span>
+    </div>
+    <input type="text" class="form-control control-project-search" placeholder='examples: "Node.js", "API", "Silas"' aria-label="Search projects" aria-describedby="label-search-projects">
+  </div>
+</div>
+
 <div class="card-deck">
   {% for project in site.data.projects %}
     {% assign mod = forloop.index | modulo: 3 %}
@@ -16,3 +25,7 @@ order: 1
     {% endif %}
   {% endfor %}
 </div>
+
+<script>
+  var projects = {{ site.data.projects | jsonify }};
+</script>

--- a/featured-projects.html
+++ b/featured-projects.html
@@ -14,7 +14,7 @@ order: 1
   </div>
 </div>
 
-<div class="card-deck">
+<div class="card-deck project-cards">
   {% for project in site.data.projects %}
     {% assign mod = forloop.index | modulo: 3 %}
 

--- a/featured-projects.html
+++ b/featured-projects.html
@@ -5,14 +5,7 @@ layout: default
 order: 1
 ---
 
-<div class="project-search">
-  <div class="input-group mb-3">
-    <div class="input-group-prepend">
-      <span class="input-group-text" id="label-search-projects">Search</span>
-    </div>
-    <input type="text" class="form-control control-project-search" placeholder='"Node.js", "API", "Silas"' aria-label="Search projects" aria-describedby="label-search-projects">
-  </div>
-</div>
+{% include component/project-search.html %}
 
 <div class="card-deck project-cards">
   {% for project in site.data.projects %}

--- a/featured-projects.html
+++ b/featured-projects.html
@@ -10,7 +10,7 @@ order: 1
     <div class="input-group-prepend">
       <span class="input-group-text" id="label-search-projects">Search</span>
     </div>
-    <input type="text" class="form-control control-project-search" placeholder='examples: "Node.js", "API", "Silas"' aria-label="Search projects" aria-describedby="label-search-projects">
+    <input type="text" class="form-control control-project-search" placeholder='"Node.js", "API", "Silas"' aria-label="Search projects" aria-describedby="label-search-projects">
   </div>
 </div>
 


### PR DESCRIPTION
This PR implements simple project searching on the Featured Projects page using [Fuse.js](http://fusejs.io) and jQuery. I've opened #48 to get some thoughts on ways we can manage and better serve JS, since this project is frequently increasing in custom and vendor JS scripts.

_Note: I'm going to open a PR to add back rendering the lead maintainer. Then that field being searchable will seem less unexpected._

### Demonstration

_Chrome 67 on macOS High Sierra_

![bydyc9in23](https://user-images.githubusercontent.com/1934719/41398714-12f7a660-6f6d-11e8-9d1f-74fbad5c6888.gif)

_Safari on iPhone X_

![demo-mobile](https://user-images.githubusercontent.com/1934719/41399117-51b98ab6-6f6e-11e8-88ce-b999eb16ec9b.gif)
