### PR TITLE
feat(atom): enable the Atom (RSS) feed plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ theme_settings:
 
 permalink: pretty
 plugins:
+  - jekyll-feed
   - jekyll-sitemap
 sass:
   sass_dir: ./_stylesheets

--- a/_includes/block/head.html
+++ b/_includes/block/head.html
@@ -15,6 +15,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/images/favicon-32x32.png' | relative_url }}">
   <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/images/favicon-16x16.png' | relative_url }}">
   <link rel="manifest" href="/site.webmanifest">
+  {% feed_meta %}
 
   {% if page.canonical %}
     <link rel="canonical" href="{{ page.canonical }}">


### PR DESCRIPTION
This PR enables the optional [Atom (RSS) feed plugin](https://help.github.com/articles/atom-rss-feeds-for-github-pages/) built into GitHub Pages.