### PR TITLE
feat: constrain featured image height on blog post cards

### DIFF
--- a/_includes/component/post-card.html
+++ b/_includes/component/post-card.html
@@ -1,0 +1,16 @@
+<div class="card card--post mb-3 shadow hoverable border-0">
+  <img class="card-img-top" src="{{ post.cover }}" alt="Article featured image">
+  <div class="card-body">
+    <h5 class="card-title text-font-headline">{{ post.title }}</h5>
+
+    <p class="card-text">
+      <small class="text-muted">Published {{ post.date | date: '%B %d, %Y' }}</small>
+    </p>
+
+    <p class="card-text">{{ post.excerpt }}</p>
+
+    <a href="{{ post.url }}" class="btn btn-primary" title="{{ post.title }}" role="button">
+      Read Article
+    </a>
+  </div>
+</div>

--- a/_stylesheets/appstyles.scss
+++ b/_stylesheets/appstyles.scss
@@ -24,6 +24,7 @@
 @import 'components/button';
 @import 'components/card';
 @import 'components/masthead';
+@import 'components/post-card';
 @import 'components/project-card';
 
 /* Pages */

--- a/_stylesheets/components/_post-card.scss
+++ b/_stylesheets/components/_post-card.scss
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------------
+// This file contains styles for the blog post card component
+// -----------------------------------------------------------------------------
+
+.card--post {
+  .card-img-top {
+    width: 100%;
+    height: 140px;
+    object-fit: cover;
+  }
+  @media (min-width: 768px) {
+    .card-img-top {
+      height: 16vw;
+    }
+  }
+}

--- a/blog-posts.html
+++ b/blog-posts.html
@@ -8,22 +8,9 @@ order: 2
 <div class="card-deck">
   {% for post in site.posts %}
     {% assign mod = forloop.index | modulo: 3 %}
-    <div class="card mb-3 shadow hoverable border-0">
-      <img class="card-img-top" src="{{ post.cover }}" alt="Article featured image">
-      <div class="card-body">
-        <h5 class="card-title text-font-headline">{{ post.title }}</h5>
 
-        <p class="card-text">
-          <small class="text-muted">Published {{ post.date | date: '%B %d, %Y' }}</small>
-        </p>
+    {% include component/post-card.html post=post %}
 
-        <p class="card-text">{{ post.excerpt }}</p>
-
-        <a href="{{ post.url }}" class="btn btn-primary" title="{{ post.title }}" role="button">
-          Read Article
-        </a>
-      </div>
-    </div>
     {% if mod == 0 %}
     <div class="w-100 d-none d-sm-block"><!-- wrap every 3 on md--></div>
     {% endif %}


### PR DESCRIPTION
This PR cleans up the blog post cards by setting a fixed image height for small screens while allowing tablets and up to use a fluid image height. The height values are subjective.

### ❯ 📷Screenshots

###### Issue (current)

![screen shot 2018-09-01 at 7 30 08 pm](https://user-images.githubusercontent.com/1934719/44951632-d07df380-ae1d-11e8-8eae-3138fe057464.png)

###### Mobile

<img width="378" alt="screen shot 2018-09-01 at 7 22 59 pm" src="https://user-images.githubusercontent.com/1934719/44951579-ac6de280-ae1c-11e8-996d-48c439546d44.png">

###### Desktop

![screen shot 2018-09-01 at 7 19 13 pm](https://user-images.githubusercontent.com/1934719/44951598-f9ea4f80-ae1c-11e8-8199-21f47a4e5ef6.png)

###### Responsiveness (> Mobile = Fluid)

![ieidbottnf](https://user-images.githubusercontent.com/1934719/44951615-61a09a80-ae1d-11e8-9a94-57d541ec0f23.gif)
