### PR TITLE
Add page metadata for Twitter card

### DIFF
--- a/_includes/block/head.html
+++ b/_includes/block/head.html
@@ -26,6 +26,8 @@
   <meta property="og:locale" content="en_US">
   <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:url" content="{{ site.url }}{{ page.url}}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@GodaddyOSS">
 
   {% if page.cover %}
     <meta property="og:image" content="{{ site.url }}{{ page.cover }}">
@@ -37,10 +39,6 @@
     <meta property="og:title" content="{{ page.title }} — {{ site.title }}">
   {% else %}
     <meta property="og:title" content="{{ site.title }}">
-  {% endif %}
-
-  {% if page.title %}
-    <meta name="twitter:title" content="{{ page.title }} | @GodaddyOSS">
   {% endif %}
 
   {% if page.excerpt %}


### PR DESCRIPTION
Does not look great now: https://twitter.com/dnasevic/status/1052098536953839616

Twitter cards should work with open-graph data per the description at the end of [this](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started) article. I think what's missing here is the `twitter:card` definition and we don't have to duplicate the open-graph to twitter meta data.

Twitter Card validator for testing: https://cards-dev.twitter.com/validator