### PR TITLE
feat: add new recent posts card to the home page

### DIFF
--- a/_includes/component/recent-posts.html
+++ b/_includes/component/recent-posts.html
@@ -1,0 +1,33 @@
+<div class="row px-3 mb-3">
+  <div class="col-xs-12">
+    <div class="card shadow border-0 p-3">
+      <h3 class="mb-3">Recent Posts</h3>
+
+      <div class="list-group mb-3">
+        {% for post in site.posts limit:3 %}
+          <a href="{{ post.url }}" title="Read post" class="list-group-item list-group-item-action flex-column align-items-start">
+            <div class="d-flex w-100 justify-content-between">
+              <h5 class="mb-1">{{ post.title }}</h5>
+              <small class="text-right">{{ post.date | date: '%B %d, %Y' }}</small>
+            </div>
+            <p class="mb-1">{{ post.excerpt }}</p>
+            <small>
+              {% for author in post.authors %}
+              By <img class="rounded mx-1" src="{{ author.photo }}" alt="{{ author.name }}" width="14">
+              {{ author.name }}
+              {% endfor %}
+            </small>
+          </a>
+        {% endfor %}
+      </div>
+
+      <div class="row">
+        <div class="col-xs-12 col-md-6 offset-md-3 col-lg-4 offset-lg-4">
+          <a class="btn btn-block btn-primary" href="{{ '/blog-posts' | relative_url }}" role="button">
+            View All
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: home
 hide: true
 ---
 
-<div class="action-cards row">
+<div class="action-cards row mb-2">
   <div class="col-sm-6">
     <div class="card shadow border-0 mb-3 text-center">
       <div class="card-body">
@@ -31,3 +31,5 @@ hide: true
     </div>
   </div>
 </div>
+
+{% include component/recent-posts.html %}


### PR DESCRIPTION
This PR introduces a new recent posts card to the home page.

### Screenshots

###### Desktop / FireFox

![screenshot_2018-10-23 home godaddy open source center](https://user-images.githubusercontent.com/1934719/47405825-490b7d00-d708-11e8-8cf0-b02ac94d5f16.png)

###### iPhone X / Safari

<img width="333" alt="screen shot 2018-10-23 at 9 09 00 pm" src="https://user-images.githubusercontent.com/1934719/47405837-56286c00-d708-11e8-9037-b888ce6a7ad4.png">
