### PR TITLE
feat: update /blog and /projects routes to be more concise

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ url: "https://godaddy.github.io"
 analytics_id: UA-37178807-20
 applicant_source: APPLICANT_SOURCE-3-119
 github_username:  godaddy
-twitter_username: GodaddyOSS
+twitter_username: GoDaddyOSS
 
 theme_settings:
   title: GoDaddy Open Source
@@ -24,9 +24,12 @@ theme_settings:
     Copyright © 1999 - 2018 GoDaddy Operating Company, LLC. All Rights Reserved.
 
 permalink: pretty
+
 plugins:
   - jekyll-feed
+  - jekyll-redirect-from
   - jekyll-sitemap
+
 sass:
   sass_dir: ./_stylesheets
   style: compressed

--- a/blog.html
+++ b/blog.html
@@ -1,9 +1,11 @@
 ---
 title: Blog Posts
-slug: blog-posts
+slug: blog
 layout: default
 order: 2
 excerpt: Blog posts about the technology and tools we're using at GoDaddy.
+redirect_from:
+  - /blog-posts
 ---
 
 <div class="card-deck">

--- a/projects.html
+++ b/projects.html
@@ -1,9 +1,11 @@
 ---
 title: Featured Projects
-slug: featured-projects
+slug: projects
 layout: default
 order: 1
 excerpt: Open source projects created and maintained by GoDaddy engineers.
+redirect_from:
+  - /featured-projects
 ---
 
 {% include component/project-search.html %}


### PR DESCRIPTION
I've often felt these routes are unnecessarily overqualified: _featured_ projects, _blog_ posts. This PR updates those page routes to be more concise, and [adds redirects](https://help.github.com/articles/redirects-on-github-pages/) for the legacy paths.