### PR TITLE
Revert "feat: update /blog and /projects routes to be more concise"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ url: "https://godaddy.github.io"
 analytics_id: UA-37178807-20
 applicant_source: APPLICANT_SOURCE-3-119
 github_username:  godaddy
-twitter_username: GoDaddyOSS
+twitter_username: GodaddyOSS
 
 theme_settings:
   title: GoDaddy Open Source
@@ -24,12 +24,9 @@ theme_settings:
     Copyright © 1999 - 2018 GoDaddy Operating Company, LLC. All Rights Reserved.
 
 permalink: pretty
-
 plugins:
   - jekyll-feed
-  - jekyll-redirect-from
   - jekyll-sitemap
-
 sass:
   sass_dir: ./_stylesheets
   style: compressed

--- a/blog-posts.html
+++ b/blog-posts.html
@@ -1,11 +1,9 @@
 ---
 title: Blog Posts
-slug: blog
+slug: blog-posts
 layout: default
 order: 2
 excerpt: Blog posts about the technology and tools we're using at GoDaddy.
-redirect_from:
-  - /blog-posts
 ---
 
 <div class="card-deck">

--- a/featured-projects.html
+++ b/featured-projects.html
@@ -1,11 +1,9 @@
 ---
 title: Featured Projects
-slug: projects
+slug: featured-projects
 layout: default
 order: 1
 excerpt: Open source projects created and maintained by GoDaddy engineers.
-redirect_from:
-  - /featured-projects
 ---
 
 {% include component/project-search.html %}


### PR DESCRIPTION
Reverts godaddy/godaddy.github.io#85 because something is wrong with the "projects" route.