### PR TITLE
feat: add a featured repos card to the home page

### DIFF
--- a/_includes/block/scripts.html
+++ b/_includes/block/scripts.html
@@ -38,6 +38,10 @@
 </script>
 {% endif %}
 
+{% if page.url == '/' %}
+<script type="module" src="{{ '/assets/scripts/featured-repos.js' | relative_url }}"></script>
+{% endif %}
+
 {% if page.slug contains 'featured-projects' %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.2.1/fuse.min.js"></script>
 <script>

--- a/_includes/component/featured-repos.html
+++ b/_includes/component/featured-repos.html
@@ -1,0 +1,37 @@
+<div class="featured-repos row d-none">
+  <div class="col">
+    <div class="card shadow border-0 p-3 text-center">
+      <h3 class="mb-3">Featured Repository</h3>
+
+      <div id="featured-repos-carousel" class="carousel slide" data-ride="carousel" data-interval="7000">
+        <div id="featured-repos" class="carousel-inner">
+          <template id="featured-repo-template">
+            <div class="carousel-item">
+
+              <small>
+                <span class="badge small featured-repo-language mb-2">
+                  Unknown
+                </span>
+              </small>
+
+              <h4 class="title mb-2">
+                <a class="featured-repo-title" href=""></a>
+              </h4>
+
+              <p class="featured-repo-description"></p>
+
+              <div class="btn-group btn-group-sm mb-3" role="group" aria-label="Repo details">
+                <a role="button" href="" class="button-stargazers-count btn btn-light" title="View stars"></a>
+                <a role="button" href="" class="button-forks-count btn btn-light" title="View forks"></a>
+              </div>
+            </div>
+          </template>
+        </div>
+        <ol id="featured-repos-indicators" class="carousel-indicators mt-3 mb-0"></ol>
+        <template id="featured-carousel-indicator">
+          <li data-target="#featured-repos-carousel" data-slide-to=""></li>
+        </template>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/component/recent-posts.html
+++ b/_includes/component/recent-posts.html
@@ -1,5 +1,5 @@
-<div class="row px-3 mb-3">
-  <div class="col-xs-12">
+<div class="row mb-3">
+  <div class="col">
     <div class="card shadow border-0 p-3">
       <h3 class="mb-3">Recent Posts</h3>
 

--- a/_stylesheets/appstyles.scss
+++ b/_stylesheets/appstyles.scss
@@ -23,6 +23,7 @@
 @import 'components/authors-panel';
 @import 'components/button';
 @import 'components/card';
+@import 'components/featured-repos-card';
 @import 'components/masthead';
 @import 'components/post-card';
 @import 'components/project-card';

--- a/_stylesheets/components/_featured-repos-card.scss
+++ b/_stylesheets/components/_featured-repos-card.scss
@@ -1,0 +1,14 @@
+.featured-repos {
+  .carousel-indicators {
+    position: relative;
+  }
+
+  .carousel-indicators li {
+    background-color: #999;
+    background-color: rgba(70, 70, 70, .25);
+  }
+
+  .carousel-indicators .active {
+    background-color: #444;
+  }
+}

--- a/assets/scripts/featured-repos.js
+++ b/assets/scripts/featured-repos.js
@@ -1,0 +1,72 @@
+(async () => {
+  const url = 'https://godaddy-featured-repos.now.sh';
+
+  const dom = {
+    select: document.querySelector.bind(document)
+  };
+
+  const textColorFromBackgroundColor = color => {
+    if (color.length < 5) {
+      color += color.slice(1);
+    }
+
+    return parseInt(color.replace('#', '0x'), 16) > (0xFFFFFF / 2) ? '#333' : '#fff';
+  };
+
+  try {
+    const json = await (await fetch(url)).json();
+    const repos = json.reverse().filter(repo => !!repo.description);
+
+    if (!repos.length) {
+      return unloadRow();
+    }
+
+    const template = dom.select('#featured-repo-template');
+    const container = dom.select('#featured-repos');
+
+    const indicatorTemplate = dom.select('#featured-carousel-indicator');
+    const indicatorsContainer = dom.select('#featured-repos-indicators');
+
+    repos.forEach((repo, i) => {
+      const content = template.cloneNode(true).content;
+      const indicator = indicatorTemplate.cloneNode(true).content;
+
+      indicator.querySelector('li').setAttribute('data-slide-to', i);
+
+      const a = content.querySelector('.featured-repo-title');
+      a.href = repo.url;
+      a.textContent = repo.name;
+
+      if (repo.primaryLanguage) {
+        const lang = content.querySelector('.featured-repo-language');
+        lang.textContent = repo.primaryLanguage.name;
+        lang.style.color = textColorFromBackgroundColor(repo.primaryLanguage.color);
+        lang.style.backgroundColor = repo.primaryLanguage.color;
+      }
+
+      content.querySelector('.featured-repo-description').textContent = repo.description;
+
+      const stargazersText = repo.stargazers === 1 ? '1 Star' : `${repo.stargazers} Stars`;
+      const starsButton = content.querySelector('.button-stargazers-count');
+      starsButton.href = `${repo.url}/stargazers`
+      starsButton.textContent = stargazersText;
+
+      const forksText = repo.forks === 1 ? '1 Fork' : `${repo.forks} Forks`;
+      const forksButton = content.querySelector('.button-forks-count');
+      forksButton.href = `${repo.url}/network/members`
+      forksButton.textContent = forksText;
+
+      if (i === 0) {
+        content.querySelector('.carousel-item').classList.add('active');
+        indicator.querySelector('li').classList.add('active')
+      }
+
+      container.appendChild(document.importNode(content, true));
+      indicatorsContainer.appendChild(document.importNode(indicator, true));
+    });
+
+    dom.select('.featured-repos').classList.remove('d-none');
+  } catch (error) {
+    console.warn('Error rendering featured repos.', error);
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ hide: true
 ---
 
 <div class="action-cards row mb-2">
-  <div class="col-sm-6">
+  <div class="col-sm">
     <div class="card shadow border-0 mb-3 text-center">
       <div class="card-body">
         <img class="mb-3" src="{{ '/assets/images/noun-projects.svg' | relative_url }}" height="100">
@@ -18,7 +18,7 @@ hide: true
       </div>
     </div>
   </div>
-  <div class="col-sm-6">
+  <div class="col-sm">
     <div class="card shadow border-0 mb-3 text-center">
       <div class="card-body">
         <img class="mb-3" src="{{ '/assets/images/noun-blog.svg' | relative_url }}" height="100">
@@ -33,3 +33,5 @@ hide: true
 </div>
 
 {% include component/recent-posts.html %}
+
+{% include component/featured-repos.html %}


### PR DESCRIPTION
This PR adds a new Featured Repositories card to the home page. I'm considering this card a [progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement) because it's not intended for old browsers and will fail gracefully for them.

### [View live demo on my fork](http://chrisvogt.github.io/godaddy.github.io)

---

Repository data is [served by this microservice](https://godaddy-featured-repos.now.sh) running [chrisvogt/gh-featured-repos](https://github.com/chrisvogt/gh-featured-repos). It is small (`1.31 MB`), portable and can easily be deployed elsewhere in the future. This initial version is deployed on [Now](https://zeit.co/now), by the creators of Next.js.

Since we don't have any repos tagged with the topic `featured`, I am currently targeting all repos tagged with `nodejs`. I can update this on the service once we have some repos tagged.

To deploy another instance of the server anytime in the future, just install [Now's CLI](https://zeit.co/docs/clients/now-cli) and run:

```
now chrisvogt/gh-featured-repos -e NODE_ENV=production -e GITHUB_TOKEN=YOUR_TOKEN_HERE -e GITHUB_OWNER=org:godaddy -e QUERY_SELECTOR=topic:nodejs -e ACCESS_ALLOW_ORIGIN=https://godaddy.github.io/
```

## Screenshots

###### Safari on iPhone XS Max

<img width="339" alt="safari iphone xs max" src="https://user-images.githubusercontent.com/1934719/47611225-7ca71980-da1e-11e8-9100-8c2aa139840d.png">

###### Firefox on Windows

<img width="1238" alt="firefox windows" src="https://user-images.githubusercontent.com/1934719/47611227-8b8dcc00-da1e-11e8-8ea5-14bfb0d54d2a.png">

###### Edge on Windows

<img width="886" alt="edge" src="https://user-images.githubusercontent.com/1934719/47611237-a3fde680-da1e-11e8-9798-c56c5651df18.png">

###### IE11 on Windows

_Fails with no errors_

<img width="885" alt="ie-no-errors" src="https://user-images.githubusercontent.com/1934719/47611235-9c3e4200-da1e-11e8-8a17-309f73a96f12.png">
