### PR TITLE
fix: page URLs when deployed to a subdirectory

### DIFF
--- a/_includes/component/author-panel.html
+++ b/_includes/component/author-panel.html
@@ -16,7 +16,7 @@
     <div class="col-12{% if page.authors.size > 1 %} col-md-6{% endif %}">
       <div class="author mb-3">
         <a href="{{ author.url }}">
-          <img class="rounded mr-2" src="{{ author.photo }}" alt="{{ author.name }}" width="64">
+          <img class="rounded mr-2" src="{{ author.photo | relative_url }}" alt="{{ author.name }}" width="64">
           <h6>{{ author.name }}</h6>
         </a>
       </div>

--- a/_includes/component/navigation.html
+++ b/_includes/component/navigation.html
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-top navbar-expand-md navbar-light bg-white">
-  <a class="navbar-brand text-font-headline" href="{{ '/' | absolute_url }}" title="GoDaddy Open Source">
+  <a class="navbar-brand text-font-headline" href="{{ '/' | relative_url }}" title="GoDaddy Open Source">
     {{ site.theme_settings.title | default: site.title }}
   </a>
 
@@ -13,7 +13,7 @@
       {% for item in items %}
       {% if item.title and item.hide != true %}
       <li class="nav-item{% if item.url == page.url %} active{% endif %}">
-        <a class="nav-link" href="{{ item.url }}" title="{{ item.title }}">
+        <a class="nav-link" href="{{ item.url | relative_url }}" title="{{ item.title }}">
           {{ item.title }}
         </a>
       </li>

--- a/_includes/component/post-card.html
+++ b/_includes/component/post-card.html
@@ -1,6 +1,6 @@
 <div class="card card--post mb-3 shadow hoverable border-0">
-  <a href="{{ post.url }}">
-    <img class="card-img-top" src="{{ post.cover }}" alt="Article featured image">
+  <a href="{{ post.url | relative_url }}">
+    <img class="card-img-top" src="{{ post.cover | relative_url }}" alt="Article featured image">
   </a>
 
   <div class="card-body">
@@ -12,7 +12,7 @@
 
     <p class="card-text">{{ post.excerpt }}</p>
 
-    <a href="{{ post.url }}" class="btn btn-primary" title="{{ post.title }}" role="button">
+    <a href="{{ post.url | relative_url }}" class="btn btn-primary" title="{{ post.title }}" role="button">
       Read Article
     </a>
   </div>

--- a/_includes/component/project-card.html
+++ b/_includes/component/project-card.html
@@ -6,7 +6,7 @@
     {% for link in project.links %}
     <a
       class="card-link"
-      href="{{ link.url }}"
+      href="{{ link.url | relative_url }}"
       title="{{ link.title }}">
       {% capture type %}{{ link.type }}{% endcapture %}
       {% include function/get-project-text.html type=type %}

--- a/_includes/component/recent-posts.html
+++ b/_includes/component/recent-posts.html
@@ -5,7 +5,7 @@
 
       <div class="list-group mb-3">
         {% for post in site.posts limit:3 %}
-          <a href="{{ post.url }}" title="Read post" class="list-group-item list-group-item-action flex-column align-items-start">
+          <a href="{{ post.url | relative_url }}" title="Read post" class="list-group-item list-group-item-action flex-column align-items-start">
             <div class="d-flex w-100 justify-content-between">
               <h5 class="mb-1">{{ post.title }}</h5>
               <small class="text-right">{{ post.date | date: '%B %d, %Y' }}</small>
@@ -13,7 +13,7 @@
             <p class="mb-1">{{ post.excerpt }}</p>
             <small>
               {% for author in post.authors %}
-              By <img class="rounded mx-1" src="{{ author.photo }}" alt="{{ author.name }}" width="14">
+              By <img class="rounded mx-1" src="{{ author.photo | relative_url }}" alt="{{ author.name }}" width="14">
               {{ author.name }}
               {% endfor %}
             </small>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ widgets:
 {% include section/header.html %}
 
 {% if page.options contains 'full-bleed-cover' %}
-<div class="cover-image" style="background-image: url({{ page.cover }});"></div>
+<div class="cover-image" style="background-image: url({{ page.cover | relative_url }});"></div>
 {% endif %}
 
 <div class="container text-line-height-2x pt-3">

--- a/_posts/2018-06-06-cicd-best-practices.md
+++ b/_posts/2018-06-06-cicd-best-practices.md
@@ -109,7 +109,7 @@ running on the build agent.
 1. deploys the image to a single instance (canary environment) using Kubernetes, and ensure it can run without issues for a small period of time (typically 2 minutes) while serving production traffic
 1. deploys the image to our production environment
 
-![Typical pipeline](/assets/images/cicd/typical-pipeline.png "A typical pipeline showing parallel steps")
+![Typical pipeline]({{ '/assets/images/cicd/typical-pipeline.png' | relative_url }} "A typical pipeline showing parallel steps")
 
 Pipelines that build multiple artifacts could also build those artifacts in parallel.
 
@@ -263,7 +263,7 @@ service that pings the Jenkins REST api to determine the current status, but the
 1. We use the [Github Autostatus Jenkins plugin](https://wiki.jenkins.io/display/JENKINS/Github+Autostatus+Plugin)
 for monitoring health of our jobs over time. This has allowed us to identify which areas of the build might need improvement. It allows you to build dashboards like the following, which shows build pass rate, average build time, and count of specific stage errors.
 
-![Sample dashboard](/assets/images/cicd/sample-build-dashboard.png "A dashboard built from the Jenkins Github Autostatus Plugin")
+![Sample dashboard]({{ '/assets/images/cicd/sample-build-dashboard.png' | relative_url }} "A dashboard built from the Jenkins Github Autostatus Plugin")
 
 This is useful for finding stages which fail too often, and for debugging build inefficiencies.
 

--- a/_posts/2018-06-12-announcing-winston-3.md
+++ b/_posts/2018-06-12-announcing-winston-3.md
@@ -186,7 +186,7 @@ for large teams & enterprises as Node.js itself.
 This LTS goal is a core reason why this release took three years to ship.
 Let's look at a recent release chart for Node.js LTS:
 
-![](/assets/images/nodejs-lts-releases.png)
+![]({{ '/assets/images/nodejs-lts-releases.png' | relative_url }})
 
 As you can see `node@4` entered "end of life" in April 2018. Until then it was
 in the active support matrix for `winston` releases. Since ES6 features

--- a/_posts/2018-06-19-jenkins-build-monitoring-plugin.md
+++ b/_posts/2018-06-19-jenkins-build-monitoring-plugin.md
@@ -177,7 +177,7 @@ pipeline {
 
 The **Pipeline Steps** build action links to this page:
 
-![Pipeline steps]({{ '/assets/images/monitoring-plugin/flowgraph-table.png | relative_url }})
+![Pipeline steps]({{ '/assets/images/monitoring-plugin/flowgraph-table.png' | relative_url }})
 
 You can see representations for every stage and step in the plugin, plus additional stuff added by Jenkins automatically.
 

--- a/_posts/2018-06-19-jenkins-build-monitoring-plugin.md
+++ b/_posts/2018-06-19-jenkins-build-monitoring-plugin.md
@@ -18,7 +18,7 @@ we use on my team at GoDaddy. One of the best practices was:
 Most of our pipelines provide per-stage status checks shown on
 the GitHub PR page. For example:
 
- ![PR Page showing status checks](/assets/images/monitoring-plugin/pr-build-page.png)
+ ![PR Page showing status checks]({{ '/assets/images/monitoring-plugin/pr-build-page.png' | relative_url }})
 
 Our engineers like this because they don't have to leave GitHub so see whether the PR built successfully.
 
@@ -132,7 +132,7 @@ In the rest of this article, I'll talk about the high-level design of the plugin
 
 The following class diagram shows the architecture of the plugin.
 
-![GitHub autostatus plugin class diagram](/assets/images/monitoring-plugin/github-autostatus-design.png)
+![GitHub autostatus plugin class diagram]({{ '/assets/images/monitoring-plugin/github-autostatus-design.png' | relative_url }})
 
 ### Job watching components
 
@@ -177,13 +177,13 @@ pipeline {
 
 The **Pipeline Steps** build action links to this page:
 
-![Pipeline steps](/assets/images/monitoring-plugin/flowgraph-table.png)
+![Pipeline steps]({{ '/assets/images/monitoring-plugin/flowgraph-table.png | relative_url }})
 
 You can see representations for every stage and step in the plugin, plus additional stuff added by Jenkins automatically.
 
 `onNewHead(flowNode)` is called with the following flowNodes.
 
-![Flownodes](/assets/images/monitoring-plugin/flownode-table.png)
+![Flownodes]({{ '/assets/images/monitoring-plugin/flownode-table.png' | relative_url }})
 
 StepStartNode Flow nodes contain additional properties to help identify their purpose,
 but that's enough detail for this example.

--- a/_posts/2018-07-10-react-native-wdio.md
+++ b/_posts/2018-07-10-react-native-wdio.md
@@ -43,7 +43,7 @@ npm install webdriverio -g
 wdio config
 ```
 
-![Screenshot showing wdio config](/assets/images/react-native-wdio/wdio-config.png)
+![Screenshot showing wdio config]({{ '/assets/images/react-native-wdio/wdio-config.png' | relative_url }})
 
 Follow the prompts to create a base WebDriverIO configuration as shown in the above picture.
 
@@ -171,7 +171,7 @@ Run the UI test:
 wdio wdio.conf.js
 ```
 
-![Screenshot showing wdio output](/assets/images/react-native-wdio/wdio-output.png)
+![Screenshot showing wdio output]({{ '/assets/images/react-native-wdio/wdio-output.png' | relative_url }})
 
 Now, you have a WebdriverIO UI test running against the local emulator. You are now set to explore [WebDriverIO Mobile API](http://webdriver.io/api.html) to continue writing more complete UI tests.
 

--- a/_posts/2018-10-28-google-lighthouse-as-a-service-lighthouse4u.md
+++ b/_posts/2018-10-28-google-lighthouse-as-a-service-lighthouse4u.md
@@ -83,7 +83,8 @@ of SVG cards surfaced directly in your Markdown or HTML.
 ```
 ![SVG card](/api/website/compare?q1=documentId:${id1}&q2=documentId:${id2}&format=svg)
 ```
-![Compare SVG](/assets/images/lh4u/widget%20compare%20-%20about.jpg)
+
+![Compare SVG]({{ '/assets/images/lh4u/widget%20compare%20-%20about.jpg' | relative_url }})
 
 
 ## Advanced Visualization
@@ -98,7 +99,7 @@ on grouping of results, time ranges, domains, scores and more is a powerful util
 Here we find our Kibana dashboard showing us how our website is performing over
 time to learn from the changes we're making.
 
-![Kibana Perf](/assets/images/lh4u/kibana%20-%20overall%20-%20about.jpg)
+![Kibana Perf]({{ '/assets/images/lh4u/kibana%20-%20overall%20-%20about.jpg' | relative_url }})
 
 ### Competition
 
@@ -106,7 +107,7 @@ Yep we even
 [compare (favorably) against competition](https://www.godaddy.com/garage/site-speed-small-business-website-white-paper/)!
 Names redacted, but we're on the high end in case you're curious.
 
-![Kibana Competitor Comparison](/assets/images/lh4u/kibana%20-%20product%20comparisons.jpg)
+![Kibana Competitor Comparison]({{ '/assets/images/lh4u/kibana%20-%20product%20comparisons.jpg' | relative_url }})
 
 
 
@@ -116,13 +117,13 @@ LH4U has two requirements, [Elasticsearch](https://www.elastic.co/downloads/elas
 and an AMQP-compatible Queue (we use [RabbitMQ](https://www.rabbitmq.com/download.html)).
 Both requirements are opensource and easy to setup if you're not already using them.
 
-![Data Flows](/assets/images/lh4u/data%20flow.jpg)
+![Data Flows]({{ '/assets/images/lh4u/data%20flow.jpg' | relative_url }})
 
 ```
 npm i -g lighthouse4u
 lh4u --config-dir ./app/config \
   --config-base defaults \
-  --config local \  
+  --config local \
   -- init
 ```
 
@@ -147,7 +148,7 @@ are available, but here is a summary of the more interesting bits:
   your own `custom` provider via `customPath`. We use this for JWT internally.
 * `http.routes` - Allows you to extend your LH4U instance with your own
   custom routes. This can be handy if you need to extend the behavior of your server.
-* `lighthouse.config` - All LH settings can be overridden to fit your needs. 
+* `lighthouse.config` - All LH settings can be overridden to fit your needs.
 * `lighthouse.validate` - A handy feature in cases where you need to verify that
   the responding page is who and what you think before you record the LH results of
   an incorrect page. Useful in cases where there may be DNS transitions. Plug in
@@ -161,7 +162,7 @@ are available, but here is a summary of the more interesting bits:
 
 
 
-## Dynamic Pipelines 
+## Dynamic Pipelines
 
 We've got a ton of useful data, but what can we do with it automagically? In the
 case of a CICD pipeline, instead of surfacing the results, nothing prevents you from


### PR DESCRIPTION
This PR fixes broken paths when deploying to user GitHub Pages by making all internal paths for images and hyperlinks relative URLs.

### [Live demo of fix](https://chrisvogt.github.io/godaddy.github.io)

You can also view a [live demo of a broken deploy](https://spreadthehelp.github.io/godaddy.github.io/blog-posts/)

---

### Screenshots

###### Before

<img width="1233" alt="screen shot 2018-10-28 at 10 46 51 am" src="https://user-images.githubusercontent.com/1934719/47619727-12828900-da9f-11e8-84f2-fd622ecd2d3a.png">

###### After

<img width="1233" alt="screen shot 2018-10-28 at 10 47 02 am" src="https://user-images.githubusercontent.com/1934719/47619730-19a99700-da9f-11e8-80e1-4a91f8e4cb58.png">
