### PR TITLE
Fix large monitor width

### DIFF
--- a/_stylesheets/layout/_post.scss
+++ b/_stylesheets/layout/_post.scss
@@ -1,8 +1,4 @@
 .layout--post {
-  .container {
-    max-width: 40em;
-  }
-
   .cover-image {
     background-origin: border-box;
     background-position: center;


### PR DESCRIPTION
I have a large monitor, so viewing articles on them looks a little silly:

<img width="2070" alt="screen shot 2019-02-26 at 12 00 47 pm" src="https://user-images.githubusercontent.com/6868877/53442696-bbde7a80-39be-11e9-8359-3d2fdb788680.png">

I removed the maximum width of the articles to simply use Bootstrap's `.container` instead (which these articles already use)

<img width="2076" alt="screen shot 2019-02-26 at 12 01 15 pm" src="https://user-images.githubusercontent.com/6868877/53442743-cf89e100-39be-11e9-9b05-40f7abb2949f.png">

Mobile-width viewing is unchanged.