### PR TITLE
feat(brand): update name to GoDaddy Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GoDaddy Open Source HQ
+# GoDaddy Engineering Blog
 
 Source code for GoDaddy's GitHub page at [godaddy.github.io](https://godaddy.github.io). Created and maintained by our engineers, this site contains blog posts about the technology and tools we're using at GoDaddy to create software which empowers small businesses around the world to build and market their digital identities.
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: GoDaddy Open Source HQ
+title: GoDaddy Engineering Blog
 description: > # this means to ignore newlines until the next key
   Information from our engineering team about the technology and tools we
   use to create software which empowers small businesses around the world
@@ -13,7 +13,7 @@ github_username:  godaddy
 twitter_username: GodaddyOSS
 
 theme_settings:
-  title: Open Source HQ
+  title: GoDaddy Engineering
   home_headline: GoDaddy ♡<br class="d-block d-md-none"> Open Source
   home_tagline: >
     Joining forces with the<br class="d-block d-sm-none"> open source community

--- a/_includes/component/navigation.html
+++ b/_includes/component/navigation.html
@@ -6,7 +6,7 @@
 </nav>
 
 <nav class="navbar navbar-top navbar-expand-md navbar-light bg-white">
-  <a class="navbar-brand font-weight-bold" href="{{ '/' | absolute_url }}" title="GoDaddy Open Source">
+  <a class="navbar-brand font-weight-bold" href="{{ '/' | absolute_url }}" title="GoDaddy Engineering">
     {{ site.theme_settings.title | default: site.title }}
   </a>
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ hide: true
       <div class="card-body">
         <img class="mb-3" src="{{ '/assets/images/noun-projects.svg' | relative_url }}" height="100">
         <h4 class="card-title">Projects</h4>
-        <p class="card-text">Projects created and maintained by GoDaddy engineers</p>
+        <p class="card-text">Open source projects created and maintained by GoDaddy engineers</p>
       </div>
       <div class="card-footer">
         <a href="{{ '/featured-projects' | relative_url }}" title="View projects" class="btn btn-primary">


### PR DESCRIPTION
The current blog name is confusing some folks who think the intention is to blog only about open source contributions. Proposing changing the name to GoDaddy Engineering.