### PR TITLE
feat(projects): make it easier to navigate to all godaddy projects

### DIFF
--- a/_includes/component/all-projects.html
+++ b/_includes/component/all-projects.html
@@ -1,0 +1,10 @@
+<div class="card-body">
+  <div class="col-xs-12 col-md-6 offset-md-3 col-lg-4 offset-lg-4">
+    <a
+       class="btn btn-block btn-primary"
+       href="https://github.com/godaddy"
+       role="button">
+      View All
+    </a>
+  </div>
+</div>

--- a/featured-projects.html
+++ b/featured-projects.html
@@ -23,3 +23,5 @@ excerpt: Open source projects created and maintained by GoDaddy engineers.
 <script>
   var projects = {{ site.data.projects | jsonify }};
 </script>
+
+{% include component/all-projects.html %}


### PR DESCRIPTION
Measuring this change:
We currently have a link to github.com/godaddy in the site footer, but I thought it was hard to find. I'll compare outgoing traffic to that url as well as outgoing traffic to github links on the featured projects page for the month before and after this change.
