### PR TITLE
Modified blog absolute links to be relative links

### DIFF
--- a/_posts/2018-06-06-cicd-best-practices.md
+++ b/_posts/2018-06-06-cicd-best-practices.md
@@ -377,7 +377,7 @@ We contribute to Jenkins as part of that culture.
 
 ## Further reading
 
-- Read about our use of [Puppeteer](https://godaddy.github.io/2018/05/07/moving-from-webdriver-to-puppeteer/) in
+- Read about our use of [Puppeteer](/2018/05/07/moving-from-webdriver-to-puppeteer/) in
 testing one of our internal applications
 - [Declarative pipeline documentation](https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline)
 - [Build a multibranch Pipeline project](https://jenkins.io/doc/tutorials/build-a-multibranch-pipeline-project/)

--- a/_posts/2018-06-19-jenkins-build-monitoring-plugin.md
+++ b/_posts/2018-06-19-jenkins-build-monitoring-plugin.md
@@ -10,7 +10,7 @@ authors:
     photo: /assets/images/jxpearce.jpg
 ---
 
-I recently wrote about some of the [Jenkins CICD best practices](https://godaddy.GitHub.io/2018/06/05/cicd-best-practices/)
+I recently wrote about some of the [Jenkins CICD best practices](/2018/06/05/cicd-best-practices/)
 we use on my team at GoDaddy. One of the best practices was:
 
  **You should use declarative pipeline**.

--- a/_posts/2019-06-18-react-native-community-contribution-datetimepicker-component.md
+++ b/_posts/2019-06-18-react-native-community-contribution-datetimepicker-component.md
@@ -186,5 +186,5 @@ for the new module.
 [eslint]: https://www.npmjs.com/package/@react-native-community/eslint-config
 [orb]: https://github.com/react-native-community/react-native-circleci-orb/
 [Detox]: https://github.com/wix/detox/
-[ekke]: https://godaddy.github.io/2019/05/22/testing-react-native-using-ekke/
+[ekke]: /2019/05/22/testing-react-native-using-ekke/
 [install]: https://github.com/react-native-community/react-native-datetimepicker/#getting-started


### PR DESCRIPTION
Moving forward, all links to other content needs to be relative links! In the future, when requests to godaddy.com/engineeing are proxied to the github.io, the user should stay on godaddy.com/engineeing when clicking links. This does not change any behavior on https://godaddy.github.io/. 